### PR TITLE
Update desc.calc() call

### DIFF
--- a/libmatch/structures.py
+++ b/libmatch/structures.py
@@ -80,8 +80,10 @@ class structure:
          
          # first computes the descriptors of species that are present
          desc = quippy.descriptors.Descriptor("soap central_weight="+str(cw)+"  covariance_sigma0=0.0 atom_sigma="+str(gs)+" cutoff="+str(coff)+" n_max="+str(nmax)+" l_max="+str(lmax)+' '+lspecies+' Z='+str(sp) )   
-         psp =np.asarray(desc.calc(at,desc.dimensions(),self.species[sp])).T;
-      
+         psp = quippy.fzeros((desc.dimensions(),desc.descriptor_sizes(at)[0]))
+         desc.calc(at,descriptor_out=psp)
+         psp = np.array(psp.T)
+
          # now repartitions soaps in environment descriptors
          lenv = []
          for p in psp:


### PR DESCRIPTION
There must have been a quippy interface change - the old way desc.calc() was called was breaking down if a new version of quippy was used. This updated code should work better - could you confirm it is backwards compatible (it think it should but I am not certain). Or let me know which version of GAP/quippy you are using and I can go back and check it.
