### PR TITLE
Update desc.calc() call

### DIFF
--- a/libmatch/structures.py
+++ b/libmatch/structures.py
@@ -80,9 +80,12 @@ class structure:
          
          # first computes the descriptors of species that are present
          desc = quippy.descriptors.Descriptor("soap central_weight="+str(cw)+"  covariance_sigma0=0.0 atom_sigma="+str(gs)+" cutoff="+str(coff)+" n_max="+str(nmax)+" l_max="+str(lmax)+' '+lspecies+' Z='+str(sp) )   
-         psp = quippy.fzeros((desc.dimensions(),desc.descriptor_sizes(at)[0]))
-         desc.calc(at,descriptor_out=psp)
-         psp = np.array(psp.T)
+         try:
+            psp =np.asarray(desc.calc(at,desc.dimensions(),self.species[sp])).T
+         except TypeError:
+            psp = quippy.fzeros((desc.dimensions(),desc.descriptor_sizes(at)[0]))
+            desc.calc(at,descriptor_out=psp)
+            psp = np.array(psp.T)
 
          # now repartitions soaps in environment descriptors
          lenv = []

--- a/libmatch/structures.py
+++ b/libmatch/structures.py
@@ -80,8 +80,10 @@ class structure:
          
          # first computes the descriptors of species that are present
          desc = quippy.descriptors.Descriptor("soap central_weight="+str(cw)+"  covariance_sigma0=0.0 atom_sigma="+str(gs)+" cutoff="+str(coff)+" n_max="+str(nmax)+" l_max="+str(lmax)+' '+lspecies+' Z='+str(sp) )   
-         psp =np.asarray(desc.calc(at,desc.dimensions(),self.species[sp])).T;
-      
+         psp = quippy.fzeros((desc.dimensions(),desc.descriptor_sizes(at)[0]))
+         desc.calc(at,descriptor_out=psp)
+         psp = np.array(psp.T)
+
          # now repartitions soaps in environment descriptors
          lenv = []
          for p in psp:


### PR DESCRIPTION
You are right, this would break old quippy installations. I have updated the call so now it should work with both old and new versions.
